### PR TITLE
MDEXI-864: Update Taint Commands to work with Tf 12

### DIFF
--- a/command/taint_untaint_deployed_resource.go
+++ b/command/taint_untaint_deployed_resource.go
@@ -101,12 +101,10 @@ func TaintUntaintDeployedResource(c *commons.Context) error {
 	args := []string{}
 	var moduleMsg string
 	if c.CliContext.IsSet("module") {
-		module := fmt.Sprintf("-module=%s", c.String("module"))
+		module := fmt.Sprintf("module.%s.%s", c.String("module"), resource)
 		args = append(args, module)
 		moduleMsg = fmt.Sprintf(" in module %s", c.String("module"))
 	}
-	args = append(args, "-no-color")
-	args = append(args, resource)
 
 	fmt.Printf("%sing resource %s%s for application %s (slot %s) in %s/%s.\n",
 		strings.Title(action), resource, moduleMsg, c.String("app"), slotId, namespace, c.String("env"))

--- a/command/taint_untaint_infra_resource.go
+++ b/command/taint_untaint_infra_resource.go
@@ -111,12 +111,10 @@ func TaintUntaintInfraResource(c *commons.Context) error {
 	args := []string{}
 	var moduleMsg string
 	if c.CliContext.IsSet("module") {
-		module := fmt.Sprintf("-module=%s", c.String("module"))
+		module := fmt.Sprintf("module.%s", c.String("module"))
 		args = append(args, module)
 		moduleMsg = fmt.Sprintf(" in module %s", c.String("module"))
 	}
-	args = append(args, "-no-color")
-	args = append(args, resource)
 
 	fmt.Printf("%sing infra resource %s%s for application %s in %s/%s.\n",
 		strings.Title(action), resource, moduleMsg, c.String("app"), namespace, c.String("env"))


### PR DESCRIPTION
Terraform V12 has removed the `-module` flag when using `terraform taint`. Updated this command in `ape-dev-rt` to reflect the new syntax.